### PR TITLE
Improve compatibility with python 2 installed

### DIFF
--- a/run_redeemer.bat
+++ b/run_redeemer.bat
@@ -1,5 +1,5 @@
 @echo off
 echo Installing dependencies...
-py -3 pip install -r requirements.txt
+py -3 -m pip install -r requirements.txt
 echo Running
 py -3 humblesteamkeysredeemer.py

--- a/run_redeemer.bat
+++ b/run_redeemer.bat
@@ -1,5 +1,5 @@
 @echo off
 echo Installing dependencies...
-pip install -r requirements.txt
+py -3 pip install -r requirements.txt
 echo Running
-python humblesteamkeysredeemer.py
+py -3 humblesteamkeysredeemer.py


### PR DESCRIPTION
These changes to batch file should force script to run under Python3 even if python command itself would run python 2. This should make batch more failsafe under variety of environments