### PR TITLE
#26 This fixes the login issue with humblebundle.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ fuzzywuzzy==0.18.0
 requests==2.25.1
 requests-futures==1.0.0
 cloudscraper==1.2.58
+selenium==4.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.25.1
 requests-futures==1.0.0
 cloudscraper==1.2.58
 selenium==4.8.2
+stem==1.8.0


### PR DESCRIPTION
This is a WIP:
But the login issue #26 with humble is fixed, basically the cloudscraper is being blocked and using normal request lib from python does the job, as long we have the cookies.

However, we are still experiencing problems with redeeming from Humble, which returns a 403 error for items that have not yet been unlocked or redeemed. So far, I've only tested redeeming all keys, and it seems to be working fine for now. Here are the logs:

[logs](https://imgur.com/a/LBufDts)

Currently, I'm only using Selenium for the login process, but I believe we can also fix the redeeming issue by using Selenium for both tasks, and then leaving everything else to Steam. Here's what I suggest: we store the unredeemed keys in a local JSON file, and once Selenium has finished redeeming the keys, we can iterate over the file and redeem them.

Lastly, please note that this solution requires GeckoDriver. If you're using Windows, here are the instructions on how to install and add it to your path. For Unix/Linux users, the process should be straightforward, as most package managers (such as apt, pacman, and dnf) should have it available.

GeckoDriver Installation Instructions:

[GeckoDriver Install](https://www.browserstack.com/guide/geckodriver-selenium-python)