### PR TITLE
Redeeming humble keys via selenium

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # humble-steam-key-redeemer
+
 Python script to extract all Humble keys and redeem them on Steam automagically.
 
 This is primarily designed to be a set-it-and-forget-it tool that maximizes successful entry of keys into Steam, assuring that no Steam game goes unredeemed.
@@ -7,26 +8,44 @@ This script will login to both Humble and Steam, automating the whole process. I
 
 It will extract _all_ keys available for Steam from Humble, and check if any of the keys are already owned by the logged-in Steam user. Of those that aren't, attempt to redeem them on Steam. This is done because Steam has some pretty harsh rate limiting on key redemption -- 50 keys/hr, or 10 failed keys/hr, whichever comes first.
 
+## Getting started
+
+### Doing it yourself
+
+First install python 3.6 and run `run_redeemer.bat` (on windows). Make sure to install the [gecko driver as well](https://www.browserstack.com/guide/geckodriver-selenium-python).
+
+### Using Nix
+
+For OSX/Linux/WSL, if you install `nix` (more information [here](https://nixos.org/download.html)), you can then use `nix develop` in the terminal, which will download python & set up selenium for you.
+
 ### Notes
 
 To remove an already added account, delete the associated `.(humble|steam)cookies` file.
+
+Other janitorial files:
+`cookies.txt` - An unpicked source of your .humblecookies
+`.browser_options` - A pickle of the browser options you pick initially (tor etc)
 
 ### Dependencies
 
 Requires Python version 3.6 or above
 
-- `steam`: [ValvePython/steam](https://github.com/ValvePython/steam)  
-- `fuzzywuzzy`: [seatgeek/fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy)  
+- `steam`: [ValvePython/steam](https://github.com/ValvePython/steam)
+- `fuzzywuzzy`: [seatgeek/fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy)
 - `requests`: [requests](https://requests.readthedocs.io/en/master/)
-- `requests-futures`: [requests-futures](https://github.com/ross/requests-futures)  
-- `cloudscraper`: [cloudscraper](https://github.com/VeNoMouS/cloudscraper)
-- `python-Levenshtein`: [ztane/python-Levenshtein](https://github.com/ztane/python-Levenshtein) **OPTIONAL**  
+- `requests-futures`: [ross/requests-futures](https://github.com/ross/requests-futures)
+- `cloudscraper`: [VeNoMouS/cloudscraper](https://github.com/VeNoMouS/cloudscraper)
+- `selenium`: [selenium](https://pypi.org/project/selenium/)
+- `python-Levenshtein`: [ztane/python-Levenshtein](https://github.com/ztane/python-Levenshtein) **OPTIONAL**
 
 Install the required dependencies with
+
 ```
 pip install -r requirements.txt
 ```
+
 If you want to install `python-Levenshtein`:
+
 ```
 pip install python-Levenshtein
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,128 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "pypi-deps-db": "pypi-deps-db"
+      },
+      "locked": {
+        "lastModified": 1688837811,
+        "narHash": "sha256-MyawDLvOlGwXao/CIGvpAqTuWhivQpO41jxXtODFazY=",
+        "owner": "davhau",
+        "repo": "mach-nix",
+        "rev": "cbdf15385c835425db8b9af73a0cf90844ca7bf6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davhau",
+        "repo": "mach-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1643805626,
+        "narHash": "sha256-AXLDVMG+UaAGsGSpOtQHPIKB+IZ0KSd9WS77aanGzgc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "554d2d8aa25b6e583575459c297ec23750adb6cb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1688679045,
+        "narHash": "sha256-t3xGEfYIwhaLTPU8FLtN/pLPytNeDwbLI6a7XFFBlGo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3c7487575d9445185249a159046cc02ff364bff8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pypi-deps-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678051695,
+        "narHash": "sha256-kFFP8TN8pEKARtjK9loGdH+TU23ZbHdVLCUdNcufKPs=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "e00b22ead9d3534ba1c448e1af3076af6b234acf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "mach-nix": "mach-nix",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "Python shell flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    mach-nix.url = "github:davhau/mach-nix";
+  };
+
+  outputs = { self, nixpkgs, mach-nix, flake-utils, ... }:
+    let pythonVersion = "python39";
+    in flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        mach = mach-nix.lib.${system};
+
+        pythonEnv = mach.mkPython {
+          python = pythonVersion;
+          requirements = builtins.readFile ./requirements.txt;
+        };
+      in {
+        devShells.default = pkgs.mkShellNoCC {
+          packages = [ pythonEnv pkgs.nodejs ];
+
+          shellHook = ''
+            export PYTHONPATH="${pythonEnv}/bin/python"
+          '';
+        };
+      });
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ fuzzywuzzy==0.18.0
 requests==2.25.1
 requests-futures==1.0.0
 cloudscraper==1.2.58
+selenium==4.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.25.1
 requests-futures==1.0.0
 cloudscraper==1.2.58
 selenium==4.8.2
+stem==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ steam==1.2.0
 fuzzywuzzy==0.18.0
 requests==2.25.1
 requests-futures==1.0.0
-cloudscraper==1.2.58
+cloudscraper==1.2.69
 selenium==4.8.2
 stem==1.8.0


### PR DESCRIPTION
I've based this PR off the excellent initial work by KaiserBh (#26), and we now can redeem keys using selenium.

The issue with not being able to redeem keys was with cloudfront blocking the requests - I'm wondering if there's some extra fingerprinting at play which means selenium keeps working, but going back to cloudscraper breaks it somehow.

What still isn't working is the humble chooser mode, it's not finding months in my case and not entirely sure why. I'll have a poke around at some point, but now I've got a massive backlog to go through.

The code should be able to handle failures (the only game I had issues with was [Husk](https://store.steampowered.com/app/553960/Husk/), which had key exhaustion). I haven't gotten it to try that key a second time, so I claim it's resilient at least.

I've also added a `flake.nix` & `flake.lock` to the project - this should hopefully make installing all the new dependencies a little easier. I had it just work with the gecko driver, but I'd love someone on another machine (MacOS) to give this a shot and tell me if it works or not.